### PR TITLE
feat(cd): integrate CD with CI workflow completion

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,10 @@
 name: CD Pipeline
 
 on:
-  push:
-    branches: ["main"]
+  workflow_run:
+    workflows: ["CI Pipeline"]
+    branches: [main]
+    types: [completed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,6 +13,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Only deploy if CI workflow completed successfully
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,17 +90,13 @@ jobs:
     needs: [detect-changes, backend-ci, frontend-ci]
     # Run this job if:
     # - The workflow is not cancelled (always())
-    # - At least one of the backend or frontend jobs succeeded, OR
-    # - Both backend and frontend jobs were skipped (no changes detected)
+    # - At least one of the backend or frontend jobs succeeded
+    # - Skip if both components were skipped (no changes to analyze)
     if: |
       always() &&
       (
         needs.backend-ci.result == 'success' ||
-        needs.frontend-ci.result == 'success' ||
-        (
-          needs.backend-ci.result == 'skipped' &&
-          needs.frontend-ci.result == 'skipped'
-        )
+        needs.frontend-ci.result == 'success'
       )
     steps:
       - uses: actions/checkout@v4
@@ -118,6 +114,26 @@ jobs:
         if: needs.detect-changes.outputs.frontend-changed == 'true'
         with:
           node-version: "18"
+
+      # Cache Maven dependencies for potential backend rebuild
+      - name: Cache Maven packages
+        if: needs.detect-changes.outputs.backend-changed == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      # Cache npm dependencies for potential frontend rebuild
+      - name: Cache npm
+        if: needs.detect-changes.outputs.frontend-changed == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       # Rebuild backend artifacts for SonarCloud analysis
       - name: Rebuild backend for analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI Pipeline
 
 on:
+  # Run CI only when PRs are merged to main (triggers CD)
   push:
-    branches: ["main", "develop", "release/**", "feature/**"]
+    branches: ["main"]
+  # Run CI on PR events for all branch validation (develop, feature/*, etc.)
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
- Change CD trigger from direct push to workflow_run event
- CD now waits for CI Pipeline completion before executing
- Add safety gate to only deploy when CI concludes successfully
- Eliminate race conditions between CI and CD processes
- Leverage existing branch protection rules instead of duplicating CI
- Ensure CD never runs without successful CI validation

Benefits:
- 100% safer deployments (CD only after CI success)
- More efficient resource usage (no duplicate CI runs)
- Clear CI→CD dependency chain for better observability
- Eliminates potential race conditions between workflows